### PR TITLE
add --pam-compatible option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ eval $(envkey-source ENVKEY)
     --no-cache           do NOT cache encrypted config as a local backup even when .env file exists
     --cache-dir string   cache directory (default is $HOME/.envkey/cache)
     --env-file string    ENVKEY-containing env file name (default ".env")
+    --pam-compatible     change output format to be compatible with /etc/environment on Linux
 -f, --force              overwrite existing environment variables and/or other entries in .env file
 -h, --help               help for envkey-source
 -v, --version            prints the version

--- a/shell/shell_test/shell_test.go
+++ b/shell/shell_test/shell_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/envkey/envkey-fetch/fetch"
 	"github.com/envkey/envkey-source/shell"
+	"github.com/envkey/envkey-source/version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,10 +14,15 @@ const INVALID_ENVKEY = "Emzt4BE7C23QtsC7gb1z-3NvfNiG1Boy6XH2oinvalid-env-staging
 
 func TestSource(t *testing.T) {
 	// Test valid
-	validRes := shell.Source(VALID_ENVKEY, true, fetch.FetchOptions{false, ""})
+	validRes := shell.Source(VALID_ENVKEY, true, fetch.FetchOptions{false, "", "envkey-source", version.Version}, false)
 	assert.Equal(t, "export 'TEST'='it' 'TEST_2'='works!' 'TEST_INJECTION'=''\"'\"'$(uname)' 'TEST_SINGLE_QUOTES'='this'\"'\"' is ok' 'TEST_SPACES'='it does work!'", validRes)
 
+	// Test --pam-compatible
+	validRes2 := shell.Source(VALID_ENVKEY, true, fetch.FetchOptions{false, "", "envkey-source", version.Version}, true)
+	assert.Equal(t, "export TEST='it'\nexport TEST_2='works!'\nexport TEST_INJECTION=''$(uname)'\nexport TEST_SINGLE_QUOTES='this' is ok'\nexport TEST_SPACES='it does work!'", validRes2)
+
+
 	// Test invalid
-	invalidRes := shell.Source(INVALID_ENVKEY, true, fetch.FetchOptions{false, ""})
+	invalidRes := shell.Source(INVALID_ENVKEY, true, fetch.FetchOptions{false, "", "envkey-source", version.Version}, false)
 	assert.Equal(t, "echo 'error: ENVKEY invalid'; false", invalidRes)
 }


### PR DESCRIPTION
This option changes the output format to be compatible with /etc/environment on Linux. 

/etc/environment is parsed by PAM's pam_env module, not bash, and has different syntax that is incompatible with the normal output of envkey-source.

Not sure if this actually belongs in envkey-source though, since dumping the output to /etc/environment is a bit different than the usual "source $(envkey-source)" use case.

Right now I pipe the output of envkey-fetch through a little Python script to munge it into this format:
`envkey-fetch ${ENVKEY} | python -c 'import json, sys; print "\n".join([(k+"="+v) for k,v in sorted(json.load(sys.stdin).items())])'`

This patch generates the equivalent output with:
`envkey-source ${ENVKEY} --pam-compatible`

For reference, here are the differences between bash syntax and the /etc/environment format, as parsed by PAM
(https://github.com/linux-pam/linux-pam/blob/master/modules/pam_env/pam_env.c#L194)
- one variable per line
- "export " prefix is allowed, and has no effect
- cannot quote the variable name
- can quote the variable value
    (but this has no effect - there are no special sequences that need to be escaped)
- embedded quotes in values are treated as any other character (so should not be escaped)
- embedded newlines in values will disappear
    (a single backslash "escapes" the newline for parsing purposes, but in the actual
    environment the newline will not appear)

Note, I was unable to check the test cases in shell_test.go because the envkey there doesn't seem to be valid for me.
