### PR TITLE
Bug: Fix IN_DOCKER check in envkey-source install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ else
   ARCH="386"
 fi
 
-if [ -f /.dockerenv ]; then
+if [[ "$(cat /proc/1/cgroup 2> /dev/null | grep docker | wc -l)" > 0 ]] || [ -f /.dockerenv ]; then
   IS_DOCKER=true
 else
   IS_DOCKER=false

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ else
   ARCH="386"
 fi
 
-if [[ "$(cat /proc/1/cgroup 2> /dev/null | grep docker | wc -l)" > 0 ]]; then
+if [ -f /.dockerenv ]; then
   IS_DOCKER=true
 else
   IS_DOCKER=false


### PR DESCRIPTION
The current check for checking wether the script is running in Docker doesn't work. 

We were getting errors when running the install script

```
curl -s https://raw.githubusercontent.com/noqcks/envkey-source/master/install.sh | sh
```

The error was `main: line 86: sudo: command not found` pointing to the fact that IN_DOCKER  was not being set properly.

This error occurred when running a Docker container in Kubernetes. No error when running locally on my Mac however..

This is the result of `cat /proc/1/cgroup` on the container in Kubernetes. No `docker` in sight 😎 
```
/ # cat /proc/1/cgroup
10:pids:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
9:perf_event:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
8:net_cls,net_prio:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
7:freezer:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
6:devices:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
5:memory:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
4:blkio:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
3:cpu,cpuacct:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
2:cpuset:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
1:name=systemd:/kubepods/burstable/podcdcdfc6c-847f-11e8-a78f-066ab791945a/0b0a41962536b631030d03a3ff903807d84264cb3a669d7609b4502d14a8e23a
```

I think we should add `[ -f /.dockerenv ]` for multi-platform Docker checking.

Screenshot for more context: 
![image](https://user-images.githubusercontent.com/4740147/42536400-f4bcc1dc-845f-11e8-94ff-c2c693466f77.png)
